### PR TITLE
Refetch on expense-list screen after deleting an expense

### DIFF
--- a/screens/CreateExpenseScreen.tsx
+++ b/screens/CreateExpenseScreen.tsx
@@ -87,7 +87,7 @@ export default function CreateExpenseScreen({ navigation }: RootStackScreenProps
 
     function handleSubmit() {
         submit();
-        navigation.navigate('Root');
+        navigation.navigate("Root", { screen: "Expenses", params: { refresh: true } });
     }
 
     return (

--- a/screens/ExpenseDetailsScreen.tsx
+++ b/screens/ExpenseDetailsScreen.tsx
@@ -19,7 +19,7 @@ const EditButton = (onPress: () => void) => (
 );
 
 export default function ExpenseDetailsScreen({ navigation, route }: RootStackScreenProps<'ExpenseDetails'>) {
-    const passwordHash = useAuth;
+    const passwordHash = useAuth();
     const { expenseId, ...otherParams } = route.params;
     const { loading, error, data, refetch } = useQuery<GetExpenseQuery>(GetExpenseDocument, {
         variables: { passwordHash: passwordHash, expenseId: expenseId }

--- a/screens/ExpensesScreen.tsx
+++ b/screens/ExpensesScreen.tsx
@@ -93,10 +93,10 @@ const ListItem = ({ id, title, amount, description, category, navigateCallBack }
   )
 };
 
-export default function ExpensesScreen({ navigation }: RootTabScreenProps<'Expenses'>) {
+export default function ExpensesScreen({ navigation, route }: RootTabScreenProps<'Expenses'>) {
   const [passwordHash, setPasswordHash] = useState('');
   const [amountToRender, setAmountToRender] = useState(20);
-  const { loading, error, data } = useQuery<GetExpensesQuery>(GetExpensesDocument, {
+  const { loading, error, data, refetch } = useQuery<GetExpensesQuery>(GetExpensesDocument, {
     variables: { passwordHash }
   });
   useEffect(() => {
@@ -110,6 +110,12 @@ export default function ExpensesScreen({ navigation }: RootTabScreenProps<'Expen
       console.error("Can't retrive password hash")
     }
   }
+  useEffect(() => {
+    if (route.params?.refresh === true) {
+      console.log('refetching');
+      refetch();
+    }
+  });
   const navigateCallBack = (id: number | null | undefined) => {
     if (id === undefined || id == null) {
       alert("Transaction could not be found!")

--- a/screens/UpdateExpenseScreen.tsx
+++ b/screens/UpdateExpenseScreen.tsx
@@ -51,7 +51,7 @@ export default function UpdateExpenseScreen({ navigation, route }: RootStackScre
 
     function handleDelete() {
         deleteExpense();
-        navigation.navigate('Root');
+        navigation.navigate('Root', { screen: 'Expenses', params: { refresh: true } });
     }
 
     return (

--- a/types.tsx
+++ b/types.tsx
@@ -23,7 +23,6 @@ export type RootStackParamList = {
   ExpenseDetails: { expenseId: number, refresh: boolean };
   UpdateExpense: { id: number, amount: string, merchant?: { id?: number, name?: string }, category?: { id?: number, name?: string }, date: Moment, desc?: string } | undefined,
   ForgotPasswordModal: undefined;
-  Expenses: undefined;
   CreateCategory: undefined;
   CreateExpense: undefined;
   NotFound: undefined;
@@ -36,7 +35,7 @@ export type RootStackScreenProps<Screen extends keyof RootStackParamList> = Nati
 >;
 
 export type RootTabParamList = {
-  Expenses: undefined;
+  Expenses?: { refresh?: boolean };
   Budget: undefined;
   Reports: undefined;
   Profile: undefined;


### PR DESCRIPTION
## Description
Now, when you delete an expense, the expense list will be updated to reflect that. Also fixed a bug where expense details screen was blank.

## Related Issue
- [x] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [Expenses](https://github.com/ps-toronto-team-4/.github/issues/8)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None.
