### PR TITLE
HOTFIX: Smarter data refreshing with the useRefresh hook.

### DIFF
--- a/hooks/useRefresh.tsx
+++ b/hooks/useRefresh.tsx
@@ -1,0 +1,17 @@
+import { useIsFocused } from "@react-navigation/native";
+import { useEffect, DependencyList } from "react";
+
+/**
+ * Call a callback whenever user navigates to the screen containing this hook.
+ * Useful to refetch data which may have changed since user was last on the same screen.
+ * Eg. `useRefresh(refetch, [passwordHash])`
+ * @param onRefresh Callback to call when screen is navigated to.
+ * @param deps Same as deps in useEffect. Call callback again whenever a dep changes.
+ */
+export function useRefresh(onRefresh: () => void, deps?: DependencyList) {
+    const screenIsFocused = useIsFocused();
+
+    useEffect(() => {
+        if (screenIsFocused) onRefresh();
+    }, [screenIsFocused].concat(deps || []));
+}

--- a/screens/CreateExpenseScreen.tsx
+++ b/screens/CreateExpenseScreen.tsx
@@ -22,7 +22,7 @@ export default function CreateExpenseScreen({ navigation, route }: RootStackScre
                 desc: vals.desc || null,
             }
         });
-        navigation.navigate("Root", { screen: "Expenses", params: { refresh: true } });
+        navigation.navigate("Root");
     }
 
     return (

--- a/screens/ExpenseDetailsScreen.tsx
+++ b/screens/ExpenseDetailsScreen.tsx
@@ -11,6 +11,7 @@ import { RootStackScreenProps } from "../types";
 import { Feather } from "@expo/vector-icons";
 import moment from "moment";
 import { useAuth } from "../hooks/useAuth";
+import { useRefresh } from "../hooks/useRefresh";
 
 const EditButton = (onPress: () => void) => (
     <TouchableOpacity style={{ paddingRight: 40 }} onPress={onPress}>
@@ -25,11 +26,7 @@ export default function ExpenseDetailsScreen({ navigation, route }: RootStackScr
         variables: { passwordHash: passwordHash, expenseId: expenseId }
     });
 
-    useEffect(() => {
-        if (route.params.refresh) {
-            refetch();
-        }
-    });
+    useRefresh(refetch, [passwordHash]);
 
     useEffect(() => {
         if (data) {

--- a/screens/ExpensesScreen.tsx
+++ b/screens/ExpensesScreen.tsx
@@ -18,6 +18,8 @@ import Swipeable from 'react-native-gesture-handler/Swipeable';
 import { RootTabScreenProps } from "../types";
 import AddButton from "../components/AddButton";
 import { useAuth } from "../hooks/useAuth";
+import { useIsFocused } from "@react-navigation/native";
+import { useRefresh } from "../hooks/useRefresh";
 
 //TODO
 // - *IMPORTANT* fix virtualization issue
@@ -100,12 +102,7 @@ export default function ExpensesScreen({ navigation, route }: RootTabScreenProps
   const { loading, error, data, refetch } = useQuery<GetExpensesQuery>(GetExpensesDocument, {
     variables: { passwordHash }
   });
-  useEffect(() => {
-    if (route.params?.refresh === true) {
-      console.log('refetching');
-      refetch();
-    }
-  });
+  useRefresh(refetch, [passwordHash]);
   const navigateCallBack = (id: number | null | undefined) => {
     if (id === undefined || id == null) {
       alert("Transaction could not be found!")
@@ -116,7 +113,7 @@ export default function ExpensesScreen({ navigation, route }: RootTabScreenProps
   }
   const dailyGrouping = splitTransationsOnDate(data, amountToRender)
   function handleAddExpense() {
-    navigation.navigate('CreateExpense', { refresh: false });
+    navigation.navigate('CreateExpense');
   }
 
   const FakeFlatList = (

--- a/screens/ExpensesScreen.tsx
+++ b/screens/ExpensesScreen.tsx
@@ -107,7 +107,7 @@ export default function ExpensesScreen({ navigation, route }: RootTabScreenProps
     if (id === undefined || id == null) {
       alert("Transaction could not be found!")
     } else {
-      navigation.navigate('ExpenseDetails', { expenseId: id, refresh: false })
+      navigation.navigate('ExpenseDetails', { expenseId: id })
     }
 
   }

--- a/screens/UpdateExpenseScreen.tsx
+++ b/screens/UpdateExpenseScreen.tsx
@@ -45,7 +45,7 @@ export default function UpdateExpenseScreen({ navigation, route }: RootStackScre
                 desc: vals.desc || null
             }
         });
-        navigation.navigate('ExpenseDetails', { expenseId: route.params?.id || 0, refresh: true });
+        navigation.navigate('ExpenseDetails', { expenseId: route.params?.id || 0 });
     }
 
     function handleDelete() {

--- a/screens/UpdateExpenseScreen.tsx
+++ b/screens/UpdateExpenseScreen.tsx
@@ -51,7 +51,7 @@ export default function UpdateExpenseScreen({ navigation, route }: RootStackScre
     function handleDelete() {
         console.log('delete pressed');
         deleteExpense();
-        navigation.navigate('Root', { screen: 'Expenses', params: { refresh: true } });
+        navigation.navigate('Root');
     }
 
     return (

--- a/types.tsx
+++ b/types.tsx
@@ -19,7 +19,7 @@ export type RootStackParamList = {
   Welcome: undefined;
   SignIn: undefined;
   SignUp: undefined;
-  ExpenseDetails: { expenseId: number, refresh: boolean };
+  ExpenseDetails: { expenseId: number };
   UpdateExpense: { id: number, amount: number, merchant?: { id?: number, name?: string }, category?: { id?: number, name?: string }, date: string, desc?: string } | undefined,
   ForgotPasswordModal: undefined;
   CreateExpense: undefined;

--- a/types.tsx
+++ b/types.tsx
@@ -22,7 +22,7 @@ export type RootStackParamList = {
   ExpenseDetails: { expenseId: number, refresh: boolean };
   UpdateExpense: { id: number, amount: number, merchant?: { id?: number, name?: string }, category?: { id?: number, name?: string }, date: string, desc?: string } | undefined,
   ForgotPasswordModal: undefined;
-  CreateExpense: { refresh: boolean };
+  CreateExpense: undefined;
   CreateCategory: undefined;
   EditCategory: { id: number, name: string, color: string, details?: string | null };
   CategorySettings: undefined;
@@ -36,7 +36,7 @@ export type RootStackScreenProps<Screen extends keyof RootStackParamList> = Nati
 >;
 
 export type RootTabParamList = {
-  Expenses?: { refresh?: boolean };
+  Expenses: undefined;
   Budget: undefined;
   Reports: undefined;
   Profile: undefined;


### PR DESCRIPTION
## Description
Created a useRefresh hook that takes a callback and calls the callback whenever the screen is navigated to. This is useful for refetching data that may have changed. Changed expense list, expense details, and create/edit expense screens to utilize this new hook to update their data automatically. This solution fixes the previous refresh implementation which would refresh the data every time the component rerendered, which is inefficient and pollutes the network.

## Related Issue
- [x] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [Expenses](https://github.com/ps-toronto-team-4/.github/issues/8)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
