### PR TITLE
Fixed bug where amount input in create/edit expense wasn't selectable.

### DIFF
--- a/components/ExpenseEditForm.tsx
+++ b/components/ExpenseEditForm.tsx
@@ -99,14 +99,15 @@ export function ExpenseEditForm({ initVals, onSubmit }: ExpenseEditFormProps) {
             <View style={styles.amountInputContainer}>
                 <View style={styles.dollarSignAndAmountInput}>
                     <Text style={styles.dollarSign}>$</Text>
-                    <AdaptiveTextInput
-                        keyboardType="numeric"
-                        style={{ fontSize: 50 }}
-                        charWidth={30}
-                        value={amountText}
-                        onChangeText={setAmountText}
-                        onBlur={handleAmountBlur}>
-                    </AdaptiveTextInput>
+                    <TouchableHighlight>
+                        <AdaptiveTextInput
+                            keyboardType="numeric"
+                            style={{ fontSize: 50 }}
+                            charWidth={30}
+                            value={amountText}
+                            onChangeText={setAmountText}
+                            onBlur={handleAmountBlur} />
+                    </TouchableHighlight>
                 </View>
             </View>
             <DropdownRow


### PR DESCRIPTION
## Description
Fixed bug where amount input in create/edit expense wasn't selectable.

## Related Issue
- [x] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [Expenses](https://github.com/ps-toronto-team-4/.github/issues/8)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
