### PR TITLE
Added backdrop prop to screen.

### DIFF
--- a/components/Screen.tsx
+++ b/components/Screen.tsx
@@ -1,7 +1,7 @@
 import { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import { CompositeNavigationProp, useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { ReactElement, useEffect } from "react";
+import { ReactElement, useEffect, useMemo } from "react";
 import { SafeAreaView, TouchableWithoutFeedback } from "react-native";
 import { Keyboard, StyleSheet } from "react-native";
 import { RootStackParamList, RootStackScreenProps, RootTabParamList } from "../types";
@@ -10,13 +10,22 @@ import { View } from "./Themed";
 export interface ScreenProps {
     children?: ReactElement<any, any> | ReactElement<any, any>[];
     onDismissKeyboard?: () => void;
+    /**
+     * If backdrop is enabled, to show an element on top of the backdrop give
+     * it the styles: `zIndex: 1` and `elevation: 1`.
+     */
+    backdrop?: boolean;
 }
 
-export function Screen({ children, onDismissKeyboard}: ScreenProps) {
+export function Screen({ children, onDismissKeyboard, backdrop }: ScreenProps) {
     return (
         <TouchableWithoutFeedback onPress={() => { Keyboard.dismiss(); onDismissKeyboard && onDismissKeyboard(); }}>
             <SafeAreaView style={styles.screen}>
                 {children}
+                {
+                    backdrop &&
+                    <View style={styles.backdrop}></View>
+                }
             </SafeAreaView>
         </TouchableWithoutFeedback>
     );
@@ -26,5 +35,13 @@ const styles = StyleSheet.create({
     screen: {
         flex: 1,
         backgroundColor: 'white',
-    }
+    },
+    backdrop: {
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        height: '100%',
+        width: '100%',
+    },
 });


### PR DESCRIPTION
## Description
Added backdrop prop to screen component. If backdrop is enabled, to display something on top of the backdrop, give it the styles `zIndex: 1` and `elevation: 1`.

## Related Issue
- [ ] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [issue name](https://github.com/ps-toronto-team-4/.github/issues/ISSUENUMBER)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
