### PR TITLE
Fix budget graphs

### DIFF
--- a/components/budget/ChartDisplay.tsx
+++ b/components/budget/ChartDisplay.tsx
@@ -1,36 +1,46 @@
 import { BudgetCategory } from "../generated";
 import { View, Text } from "react-native";
-import { VictoryAxis, VictoryBar, VictoryChart } from 'victory-native';
+import { VictoryAxis, VictoryBar, VictoryChart, VictoryStack } from 'victory-native';
 
 export interface ChartDisplayProps {
     planned: number;
-    actual: number;
+    actualBudgeted: number;
+    actualUnbudgeted: number;
     height?: number;
     width?: number;
 }
 
-export function ChartDisplay({ planned, actual, height, width }: ChartDisplayProps) {
+export function ChartDisplay({ planned, actualBudgeted, actualUnbudgeted, height, width }: ChartDisplayProps) {
     return (
-        <View style={{ justifyContent: "center", alignItems: "center" }}>
+        <View style={{ justifyContent: 'center', alignItems: 'center' }}>
             <VictoryChart width={width || 360} height={height || 200} domainPadding={70} padding={{ top: 0, bottom: 30, left: 50, right: 50 }}>
                 <VictoryAxis crossAxis />
-                <VictoryBar
-                    categories={{ x: ["Planned", "Actual"] }}
-                    data={[
-                        { x: "Planned", y: planned, label: "$" + planned.toFixed(2), fill: "#4477aa" },
-                        { x: "Actual", y: actual, label: "$" + actual.toFixed(2), fill: "#aa3377" },
-                    ]}
-                    style={{
-                        data:
-                        {
-                            fill:
-                                ({ datum }) => datum.fill,
+                <VictoryStack colorScale={['#aa3377', '#e0b4cd']}>
+                    <VictoryBar
+                        categories={{ x: ['Planned', 'Actual'] }}
+                        data={[
+                            { x: 'Planned', y: planned, label: '$' + planned.toFixed(2), fill: '#4477aa' },
+                            { x: 'Actual', y: actualBudgeted, fill: '#aa3377' },
+                        ]}
+                        style={{
+                            data:
+                            {
+                                fill:
+                                    ({ datum }) => datum.fill,
+                            }
                         }
-                    }
-                    }
-                    width={200}
-                    barWidth={50} />
-
+                        }
+                        width={200}
+                        barWidth={50} />
+                    <VictoryBar
+                        categories={{ x: ['Planned', 'Actual'] }}
+                        data={[
+                            { x: 'Planned', y: 0 },
+                            { x: 'Actual', y: actualUnbudgeted, label: `${(actualBudgeted + actualUnbudgeted).toFixed(2)}` }
+                        ]}
+                        width={200}
+                        barWidth={50} />
+                </VictoryStack>
             </VictoryChart>
         </View>
 

--- a/components/budget/ChartDisplay.tsx
+++ b/components/budget/ChartDisplay.tsx
@@ -36,7 +36,7 @@ export function ChartDisplay({ planned, actualBudgeted, actualUnbudgeted, height
                         categories={{ x: ['Planned', 'Actual'] }}
                         data={[
                             { x: 'Planned', y: 0 },
-                            { x: 'Actual', y: actualUnbudgeted, label: `${(actualBudgeted + actualUnbudgeted).toFixed(2)}` }
+                            { x: 'Actual', y: actualUnbudgeted, label: `$${(actualBudgeted + actualUnbudgeted).toFixed(2)}` }
                         ]}
                         width={200}
                         barWidth={50} />

--- a/components/budget/ChartDisplay.tsx
+++ b/components/budget/ChartDisplay.tsx
@@ -17,8 +17,8 @@ export function ChartDisplay({ planned, actual, height, width }: ChartDisplayPro
                 <VictoryBar
                     categories={{ x: ["Planned", "Actual"] }}
                     data={[
-                        { x: "Planned", y: planned, label: "$" + planned.toFixed(2), fill: "purple" },
-                        { x: "Actual", y: actual, label: "$" + actual.toFixed(2), fill: "black" },
+                        { x: "Planned", y: planned, label: "$" + planned.toFixed(2), fill: "#4477aa" },
+                        { x: "Actual", y: actual, label: "$" + actual.toFixed(2), fill: "#aa3377" },
                     ]}
                     style={{
                         data:

--- a/screens/Budget/BudgetScreen.tsx
+++ b/screens/Budget/BudgetScreen.tsx
@@ -5,7 +5,7 @@ import { TouchableHighlight } from "react-native"
 import { AntDesign } from "@expo/vector-icons";
 
 import React from 'react';
-import { StyleSheet, View, ScrollView } from 'react-native';
+import { StyleSheet, View, ScrollView, Text } from 'react-native';
 import { RootTabScreenProps } from "../../types";
 import { ChartDisplay } from "../../components/budget/ChartDisplay";
 import { BudgetList } from "../../components/budget/BudgetList";
@@ -15,6 +15,7 @@ import { MONTHS_ORDER } from "../../constants/Months"
 import { Screen } from "../../components/Screen";
 import Button from "../../components/Button";
 import moment from "moment";
+import { Feather } from '@expo/vector-icons';
 
 interface HeaderButtonProps {
     direction: 'left' | 'right';
@@ -211,10 +212,19 @@ export default function BudgetScreen({ navigation, route }: RootTabScreenProps<'
                 planned={plannedAmount || 0}
                 actualBudgeted={actualAmount?.budgeted || 0}
                 actualUnbudgeted={actualAmount?.unbudgeted || 0} />
+            <>
+                {
+                    actualAmount && actualAmount.unbudgeted > 0 &&
+                    <View style={styles.warningContainer}>
+                        <Feather name="info" size={21} color="red" style={styles.warningIcon} />
+                        <Text style={styles.warningText}>${actualAmount?.unbudgeted.toFixed(2)} of expenses are unplanned.</Text>
+                    </View>
+                }
+            </>
             {
                 (selectedBudget && selectedBudget.budgetCategories && selectedBudget.budgetCategories.length > 0 &&
                     <>
-                        <View style={{ alignSelf: 'center', marginBottom: 10, }}>
+                        <View style={{ alignSelf: 'center', marginBottom: 20, }}>
                             <Button text="Add Budget" onPress={handleAddBudget} />
                         </View>
                         <View style={styles.itemSeparator}></View>
@@ -247,5 +257,20 @@ const styles = StyleSheet.create({
     itemSeparator: {
         height: 1,
         backgroundColor: 'rgba(0,0,0,0.2)',
+    },
+    warningContainer: {
+        alignItems: 'center',
+        paddingTop: 8,
+        paddingBottom: 10,
+        justifyContent: 'center',
+        flexDirection: 'row',
+    },
+    warningIcon: {
+        marginRight: 8,
+    },
+    warningText: {
+        color: 'red',
+        fontSize: 18,
+        fontWeight: '700',
     },
 });


### PR DESCRIPTION
## Description
Change chart colors. Stack graphs to show budgeted vs unbudgeted actual amount. Show red warning which shows how much in unbudgeted expenses the user has.

## Related Issue
- [x] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [Budget](https://github.com/ps-toronto-team-4/.github/issues/19)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
