### PR TITLE
P-Permissions: Made Android permissions equal to none

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
-        "backgroundColor": "#FFFFFF"
+        "backgroundColor": "#FFFFFF",
+        "permissions": []
       }
     },
     "web": {


### PR DESCRIPTION
## Description
Setting the permissions property should prevent the built app from requesting permissions we don't need

## Related Issue
- [ ] This pull request relates to at least one particular issue

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
