### PR TITLE
P-Jeremie: sync add button styles

### DIFF
--- a/screens/CategoryScreens/CategorySettingsScreen.tsx
+++ b/screens/CategoryScreens/CategorySettingsScreen.tsx
@@ -57,7 +57,7 @@ export default function CategorySettingsScreen({ navigation }: RootStackScreenPr
                     </View>
                 ))}
             <View style={styles.addBtnContainer}>
-                <AddButton size={100} onPress={() => navigation.navigate('CreateCategory')} />
+                <AddButton size={70} onPress={() => navigation.navigate('CreateCategory')} />
             </View>
         </View>
     );

--- a/screens/ExpensesScreen.tsx
+++ b/screens/ExpensesScreen.tsx
@@ -129,7 +129,7 @@ export default function ExpensesScreen({ navigation }: RootTabScreenProps<'Expen
                     keyExtractor={keyExtractor}
                     maxToRenderPerBatch={30} />
                 <View style={staticStyles.addExpenseBtn}>
-                    <AddButton size={100} onPress={handleAddExpense} />
+                    <AddButton size={70} onPress={handleAddExpense} />
                 </View>
             </View>
         );
@@ -154,8 +154,8 @@ const staticStyles = StyleSheet.create({
     },
     addExpenseBtn: {
         position: 'absolute',
-        right: 20,
-        bottom: 20,
+        right: 15,
+        bottom: 15,
     },
     dateContainer: {
         paddingTop: 20,

--- a/screens/MerchantScreens/MerchantSettingsScreen.tsx
+++ b/screens/MerchantScreens/MerchantSettingsScreen.tsx
@@ -52,7 +52,7 @@ export default function MerchantSettingsScreen({ navigation }: RootStackScreenPr
                     </View>
                 ))}
             <View style={styles.addBtnContainer}>
-                <AddButton size={100} onPress={() => navigation.navigate('CreateMerchant')} />
+                <AddButton size={70} onPress={() => navigation.navigate('CreateMerchant')} />
             </View>
         </View>
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "**/**/*"
   ],
   "compilerOptions": {
+    "jsx": "react",
     "strict": true
   }
 }


### PR DESCRIPTION
## Description
sync add button styles, making them all the same size as the one on the home screen (so slightly smaller), and fixing the positon of the expense screen's add button.

## Related Issue
- [ ] This pull request relates to at least one particular issue

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
