### PR TITLE
Fix error that shows when clicking pie chart uncategorized category in insights.

### DIFF
--- a/screens/ReportScreens/ExpandWheel.tsx
+++ b/screens/ReportScreens/ExpandWheel.tsx
@@ -56,7 +56,7 @@ export default function ExpandExpense({ navigation, route }: RootStackScreenProp
 
     const retrieveAmountSpent = (categoryName: string) => {
         if (monthlyBreakdownData?.monthBreakdown.__typename === "MonthBreakdown") {
-            let categoryIndex = monthlyBreakdownData.monthBreakdown.byCategory.findIndex(e => e.category?.name === categoryName);
+            let categoryIndex = monthlyBreakdownData.monthBreakdown.byCategory.findIndex(e => (categoryName === 'Uncategorized' && !e.category) || e.category?.name === categoryName);
             let currentCategorySpent = monthlyBreakdownData.monthBreakdown.byCategory[categoryIndex].amountSpent;
 
             if (currentCategorySpent > 0) {
@@ -73,7 +73,7 @@ export default function ExpandExpense({ navigation, route }: RootStackScreenProp
     const percentOfTotal = (categoryName: string) => {
         if (monthlyBreakdownData?.monthBreakdown.__typename === "MonthBreakdown") {
             let totalSpent = monthlyBreakdownData.monthBreakdown.totalSpent;
-            let categoryIndex = monthlyBreakdownData.monthBreakdown.byCategory.findIndex(e => e.category?.name === categoryName);
+            let categoryIndex = monthlyBreakdownData.monthBreakdown.byCategory.findIndex(e => (categoryName === 'Uncategorized' && !e.category) || e.category?.name === categoryName);
             let currentCategorySpent = monthlyBreakdownData.monthBreakdown.byCategory[categoryIndex].amountSpent;
             let delta = (currentCategorySpent) / (totalSpent);
 


### PR DESCRIPTION
## Description
Fix error that shows when clicking pie chart uncategorized category in insights.

## Related Issue
- [ ] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [issue name](https://github.com/ps-toronto-team-4/.github/issues/ISSUENUMBER)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
